### PR TITLE
[MAIN][FEAT] add StudySessions models

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,6 +46,8 @@
     "simple-import-sort/exports": "error",
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "error",
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": ["error"],
     "semi": [2, "always"],
     "max-len": [
       "warn",

--- a/modules/StudySession/models.ts
+++ b/modules/StudySession/models.ts
@@ -1,0 +1,28 @@
+export enum StudySessionMode {
+  NORMAL = "normal",
+  JEOPARDY = "jeopardy",
+  COMBINED = "combined",
+}
+
+export interface StudySessionResultData {
+  question: string;
+  answer: string;
+  cardRef: string;
+  correct: boolean;
+}
+
+export interface StudySessionResult extends StudySessionResultData {
+  id: string;
+}
+
+export interface StudySessionData {
+  mode: StudySessionMode;
+  date: string;
+  completed: boolean;
+  cardsAmount: number;
+}
+
+export interface StudySession extends StudySessionData {
+  id: string;
+  results: StudySessionResult[];
+}


### PR DESCRIPTION
## Feature name
- Agregamos los modelos de las sesiones de estudio
- Apagamos al rule `no-shadow` en `eslint` a partir de este bug reportado https://stackoverflow.com/questions/63961803/eslint-says-all-enums-in-typescript-app-are-already-declared-in-the-upper-scope

### Issue number
- #37
